### PR TITLE
Feat: use self-implemented StatementScanner

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -1,9 +1,9 @@
 package sqlsummary
 
 import (
+	"bytes"
 	"errors"
 	"io"
-	"strings"
 )
 
 type StatementScanner struct {
@@ -11,7 +11,7 @@ type StatementScanner struct {
 	insideDoubleQuote bool
 	insideBackQuote   bool
 	escape            bool
-	text              strings.Builder
+	text              bytes.Buffer
 	buf               []byte
 	n                 int
 	err               error
@@ -37,7 +37,6 @@ func (s *StatementScanner) Scan() bool {
 					continue
 				}
 				s.n -= i + 1
-				s.text.Grow(i + 1)
 				s.text.Write(s.buf[:i])
 				s.buf = s.buf[i+1:]
 				return true
@@ -56,7 +55,6 @@ func (s *StatementScanner) Scan() bool {
 			}
 		}
 
-		s.text.Grow(s.n)
 		s.text.Write(s.buf[:s.n])
 		s.n = 0
 
@@ -80,7 +78,6 @@ func (s *StatementScanner) Err() error {
 
 func NewStatementScanner(r io.Reader, maxCapacity int) *StatementScanner {
 	return &StatementScanner{
-		text: strings.Builder{},
 		buf:  make([]byte, maxCapacity),
 		r:    r,
 	}

--- a/statement.go
+++ b/statement.go
@@ -1,46 +1,87 @@
 package sqlsummary
 
 import (
-	"bufio"
+	"errors"
 	"io"
+	"strings"
 )
 
-func splitStatement(data []byte, atEOF bool) (int, []byte, error) {
-	var insideSingleQuote, insideDoubleQuote, insideBackQuote, escape bool
-	for i := 0; i < len(data); i++ {
-		if escape {
-			escape = false
-			continue
-		}
-
-		switch data[i] {
-		case ';':
-			if insideSingleQuote || insideDoubleQuote || insideBackQuote {
-				continue
-			}
-			return i + 1, data[:i], nil
-
-		case '\\':
-			escape = true
-
-		case '\'':
-			insideSingleQuote = !insideSingleQuote
-
-		case '"':
-			insideDoubleQuote = !insideDoubleQuote
-
-		case '`':
-			insideBackQuote = !insideBackQuote
-		}
-	}
-
-	return 0, data, bufio.ErrFinalToken
+type StatementScanner struct {
+	insideSingleQuote bool
+	insideDoubleQuote bool
+	insideBackQuote   bool
+	escape            bool
+	text              strings.Builder
+	buf               []byte
+	n                 int
+	err               error
+	r                 io.Reader
 }
 
-func NewStatementScanner(r io.Reader, bufferSize int) *bufio.Scanner {
-	scanner := bufio.NewScanner(r)
-	scanner.Split(splitStatement)
-	buf := make([]byte, bufferSize)
-	scanner.Buffer(buf, bufferSize)
-	return scanner
+func (s *StatementScanner) Scan() bool {
+	if s.err != nil {
+		return false
+	}
+	s.text.Reset()
+
+	for {
+		for i := 0; i < s.n; i++ {
+			if s.escape {
+				s.escape = false
+				continue
+			}
+
+			switch s.buf[i] {
+			case ';':
+				if s.insideSingleQuote || s.insideDoubleQuote || s.insideBackQuote {
+					continue
+				}
+				s.n -= i + 1
+				s.text.Grow(i + 1)
+				s.text.Write(s.buf[:i])
+				s.buf = s.buf[i+1:]
+				return true
+
+			case '\\':
+				s.escape = true
+
+			case '\'':
+				s.insideSingleQuote = !s.insideSingleQuote
+
+			case '"':
+				s.insideDoubleQuote = !s.insideDoubleQuote
+
+			case '`':
+				s.insideBackQuote = !s.insideBackQuote
+			}
+		}
+
+		s.text.Grow(s.n)
+		s.text.Write(s.buf[:s.n])
+		s.n = 0
+
+		if errors.Is(s.err, io.EOF) {
+			return true
+		}
+		s.n, s.err = s.r.Read(s.buf)
+		if s.err != nil && !errors.Is(s.err, io.EOF) {
+			return false
+		}
+	}
+}
+
+func (s *StatementScanner) Text() string {
+	return s.text.String()
+}
+
+func (s *StatementScanner) Err() error {
+	return s.err
+}
+
+func NewStatementScanner(r io.Reader, maxCapacity int) *StatementScanner {
+	return &StatementScanner{
+		text: strings.Builder{},
+		buf:  make([]byte, maxCapacity),
+		r:    r,
+	}
 }


### PR DESCRIPTION
## Problem

- If `maxCapacity` is small, command exit with status 1.
	- `bufio.Scanner` stop scanning return error.
	- Ref. https://mickey24.hatenablog.com/entry/bufio_scanner_line_length
- To avoid this, implement and serve flexible scanning process.